### PR TITLE
implement a recursive descendant pkill-ing for cancelled jobs

### DIFF
--- a/lib/os.ml
+++ b/lib/os.ml
@@ -245,14 +245,17 @@ module Macos = struct
 
   let pkill ~pid =
     let pp s ppf = Fmt.pf ppf "[ %s ]" s in
-    let delete = ["pkill"; "-9"; "-P"; pid ] in
-    sudo_result ~pp:(pp "PKILL") delete >>= fun t ->
-      match t with
-      | Ok () -> Lwt.return ()
-      | Error (`Msg m) -> (
-        Log.warn (fun f -> f "Failed to pkill for %s because %s" pid m);
-        Lwt.return ()
-      )
+    if String.length pid = 0 then (Log.warn (fun f -> f "Empty PID"); Lwt.return ())
+    else begin
+      let delete = ["pkill"; "-9"; "-P"; pid ] in
+      sudo_result ~pp:(pp "PKILL") delete >>= fun t ->
+        match t with
+        | Ok () -> Lwt.return ()
+        | Error (`Msg m) -> (
+          Log.warn (fun f -> f "Failed to pkill for %s because %s" pid m);
+          Lwt.return ()
+        )
+    end
 
   let kill_all_descendants ~pid =
     let rec kill pid : unit Lwt.t =

--- a/lib/os.ml
+++ b/lib/os.ml
@@ -198,16 +198,52 @@ module Macos = struct
           sudo_result ~pp:(pp "Deleting") delete
     end
 
-  let pkill ~user = 
-    let pp s ppf = Fmt.pf ppf "[ Mac ] %s\n" s in 
-    let delete = ["pkill"; "-u"; user ] in 
-    sudo_result ~pp:(pp "Killing") delete >|= function 
-      | Ok () -> () 
-      | _ -> Log.warn (fun f -> f "Failed to pkill for %s" user); ()
+  (* HACK: I couldn't find a way to get the PID of the running command for the macOS sandbox.
+   * So here we list processes and match on the command... to get the PID... *)
+  let find_pid ~cmd =
+    pread ["sudo"; "ps"; "-eo"; "pid,args"] >|= fun s ->
+    let lines = Astring.String.cuts ~sep:"\n" s in
+    let pid_arg s =
+      let lst = Astring.String.cuts ~sep:" " s in
+      let lst = List.filter (fun s -> String.length s <> 0) lst in
+      if List.length lst > 2 then Some (List.hd lst, String.concat " " (List.tl lst)) else None
+    in
+    let pid_args = List.filter_map pid_arg lines in
+    Option.map fst (List.find_opt (fun (_, c) -> Log.info (fun f -> f "Does %s match %s" cmd c); String.equal cmd c) pid_args)
 
-  let copy_template ~base ~local = 
-    let pp s ppf = Fmt.pf ppf "[ Mac ] %s\n" s in 
-    sudo_result ~pp:(pp "Rsync Brew") ["rsync"; "-avq"; base ^ "/"; local]
+  let descendants ~pid =
+    if String.length pid = 0 then Lwt.return []
+    else
+    Lwt.catch
+      (fun () -> pread ["sudo"; "pgrep"; "-P"; pid ] >|= fun s -> Astring.String.cuts ~sep:"\n" s)
+      (* Errors if there are none, probably errors for other reasons too... *)
+      (fun _ -> Lwt.return [])
+
+  let pkill ~pid =
+    let pp s ppf = Fmt.pf ppf "[ %s ]" s in
+    if String.length pid = 0 then (Log.warn (fun f -> f "Empty PID"); Lwt.return ())
+    else begin
+      let delete = ["pkill"; "-9"; "-P"; pid ] in
+      sudo_result ~pp:(pp "PKILL") delete >>= fun t ->
+        match t with
+        | Ok () -> Lwt.return ()
+        | Error (`Msg m) -> (
+          Log.warn (fun f -> f "Failed to pkill for %s because %s" pid m);
+          Lwt.return ()
+        )
+    end
+
+  let kill_all_descendants ~pid =
+    let rec kill pid : unit Lwt.t =
+      descendants ~pid >>= fun ds ->
+      Lwt_list.iter_s kill ds >>= fun () ->
+      pkill ~pid
+    in
+      kill pid
+
+  let copy_template ~base ~local =
+    let pp s ppf = Fmt.pf ppf "[ %s ]" s in
+    sudo_result ~pp:(pp "RSYNC") ["rsync"; "-avq"; base ^ "/"; local]
 
   let change_home_directory_for ~user ~homedir = 
     ["dscl"; "."; "-create"; "/Users/" ^ user ; "NFSHomeDirectory"; homedir ]

--- a/lib/os.ml
+++ b/lib/os.ml
@@ -247,12 +247,12 @@ module Macos = struct
     let pp s ppf = Fmt.pf ppf "[ %s ]" s in
     if String.length pid = 0 then (Log.warn (fun f -> f "Empty PID"); Lwt.return ())
     else begin
-      let delete = ["pkill"; "-9"; "-P"; pid ] in
-      sudo_result ~pp:(pp "PKILL") delete >>= fun t ->
+      let delete = ["kill"; "-9";  pid ] in
+      sudo_result ~pp:(pp "KILL") delete >>= fun t ->
         match t with
         | Ok () -> Lwt.return ()
         | Error (`Msg m) -> (
-          Log.warn (fun f -> f "Failed to pkill for %s because %s" pid m);
+          Log.warn (fun f -> f "Failed to kill process %s because %s" pid m);
           Lwt.return ()
         )
     end

--- a/lib/os.ml
+++ b/lib/os.ml
@@ -56,6 +56,32 @@ let default_exec ?cwd ?stdin ?stdout ?stderr ~pp argv =
   | Unix.WSIGNALED x -> Fmt.error_msg "%t failed with signal %d" pp x
   | Unix.WSTOPPED x -> Fmt.error_msg "%t stopped with signal %a" pp pp_signal x
 
+(* similar to default_exec except useing open_process_none in order to get the
+   pid of the forked process. On macOS this allows for cleaner job cancellations *)
+let open_process ?cwd ?stdin ?stdout ?stderr ?pp:_ argv =
+  Logs.info (fun f -> f "Fork exec %a" pp_cmd argv);
+  let proc =
+    let stdin  = Option.map redirection stdin in
+    let stdout = Option.map redirection stdout in
+    let stderr = Option.map redirection stderr in
+    let process = Lwt_process.open_process_none ?cwd ?stdin ?stdout ?stderr ("", (Array.of_list argv)) in
+    (process#pid, process#status)
+  in
+  Option.iter close_redirection stdin;
+  Option.iter close_redirection stdout;
+  Option.iter close_redirection stderr;
+  proc
+
+let process_result ~pp proc =
+  proc >|= (function
+  | Unix.WEXITED n -> Ok n
+  | Unix.WSIGNALED x -> Fmt.error_msg "%t failed with signal %d" pp x
+  | Unix.WSTOPPED x -> Fmt.error_msg "%t stopped with signal %a" pp pp_signal x)
+  >>= function
+  | Ok 0 -> Lwt_result.return ()
+  | Ok n -> Lwt.return @@ Fmt.error_msg "%t failed with exit status %d" pp n
+  | Error e -> Lwt_result.fail (e : [`Msg of string] :> [> `Msg of string])
+
 (* Overridden in unit-tests *)
 let lwt_process_exec = ref default_exec
 
@@ -212,8 +238,6 @@ module Macos = struct
     Option.map fst (List.find_opt (fun (_, c) -> Log.info (fun f -> f "Does %s match %s" cmd c); String.equal cmd c) pid_args)
 
   let descendants ~pid =
-    if String.length pid = 0 then Lwt.return []
-    else
     Lwt.catch
       (fun () -> pread ["sudo"; "pgrep"; "-P"; pid ] >|= fun s -> Astring.String.cuts ~sep:"\n" s)
       (* Errors if there are none, probably errors for other reasons too... *)
@@ -221,17 +245,14 @@ module Macos = struct
 
   let pkill ~pid =
     let pp s ppf = Fmt.pf ppf "[ %s ]" s in
-    if String.length pid = 0 then (Log.warn (fun f -> f "Empty PID"); Lwt.return ())
-    else begin
-      let delete = ["pkill"; "-9"; "-P"; pid ] in
-      sudo_result ~pp:(pp "PKILL") delete >>= fun t ->
-        match t with
-        | Ok () -> Lwt.return ()
-        | Error (`Msg m) -> (
-          Log.warn (fun f -> f "Failed to pkill for %s because %s" pid m);
-          Lwt.return ()
-        )
-    end
+    let delete = ["pkill"; "-9"; "-P"; pid ] in
+    sudo_result ~pp:(pp "PKILL") delete >>= fun t ->
+      match t with
+      | Ok () -> Lwt.return ()
+      | Error (`Msg m) -> (
+        Log.warn (fun f -> f "Failed to pkill for %s because %s" pid m);
+        Lwt.return ()
+      )
 
   let kill_all_descendants ~pid =
     let rec kill pid : unit Lwt.t =


### PR DESCRIPTION
This PR implements a (WIP) strategy for handling cancelled jobs by calling `pkill` on a list of PIDs calculated recursively from the parent process. Perhaps there's a way to extract the initial PID but I couldn't work it out so I opted for the hacky `ps`-and-search-for-the-command approach. 

I tested this on a few jobs so far like: 

```
((from macos-homebrew-ocaml-4.12)
 (run (shell "sleep 220")))
```

This definitely didn't work in the old implementation -- this would just be hanging about even when you did cancel it. In fact 220 seconds later it would log to obuilder 😬 , at least from my tests this current implementation does kill all the processes associated with this one.

I'll now test it for the more complicated ones like `opam depext -u`. 
